### PR TITLE
Package the aquilon protocols with setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+build
+dist
+*pb2.py
+*.cc
+*.h
+MANIFEST
+*.old
+*~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.proto

--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+Protocol buffers definitions for Quattor.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,58 @@
+#!/bin/env python
+
+from distutils.core import setup
+from distutils.command.build import build
+from distutils.extension import Extension
+import sys
+import os
+import subprocess
+from glob import glob
+
+protoc = os.environ.get("PROTOC")
+if not protoc and os.path.exists("/usr/bin/protoc"):
+    protoc = "/usr/bin/protoc"
+else:
+    raise Exception("protoc not found")
+
+class GenerateProto(build):
+    def run(self):
+        """Invokes the Protocol Compiler to generate a _pb2.py from
+        the given .proto file. Does nothing if the output already
+        exists and is newer than the input."""
+        for source in glob("*.proto"):
+            output = source.replace(".proto", "_pb2.py")
+            if not os.path.exists(source):
+                print("Can't find required file: " + source)
+                sys.exit(-1)
+            if (not os.path.exists(output) or
+                (os.path.exists(source) and
+                 os.path.getmtime(source) > os.path.getmtime(output))):
+                print("Generating %s..." % output)
+
+            if not protoc:
+                sys.stderr.write(
+                    "protoc is not installed nor found in ../src. Please compile it "
+                    "or install the binary package.\n")
+                sys.exit(-1)
+            protoc_command = [protoc, '--python_out=.',
+                              '--cpp_out=.', source]
+            if subprocess.call(protoc_command) != 0:
+                sys.exit(-1)
+
+py_modules = [x.replace(".proto", "_pb2") for x in glob("*.proto")]
+
+setup(name="aquilon-protocols",
+      version="1.10",
+      description="Protocol buffers definitions and modules for Aquilon",
+      long_description="""Protocol buffers definitions for Aquilon.
+
+Includes the protobuf declarations and the Python and C++ implementations.""",
+      url="http://quattor.org",
+      license="Apache 2.0",
+      data_files = [("/usr/include", glob("*.h")),
+                    ("/usr/share/protocols/aquilon/cpp", glob("*.cc")),
+                    ("/usr/share/protocols/aquilon/protobuf", glob("*.proto"))],
+      py_modules = py_modules,
+      author="Quattor project",
+      author_email="quattor-discuss@lists.sourceforge.net",
+      cmdclass = { 'build' : GenerateProto })

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 from distutils.core import setup
 from distutils.command.build import build


### PR DESCRIPTION
This preserves the file layout and doesn't interfere with the existing makefile.

CPP and protobuf files are installed in `/usr/share/protocols/aquilon`.

The Python libraries go to %{python_sitelib}.  After looking at the code in Aquilon, they don't seem to belong into an `aquilon` namespace.
